### PR TITLE
Incorporate upstream changes: EOL base image and toolchain v0.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian/eol:buster-slim
 ENV DEBIAN_FRONTEND noninteractive
 
 # Timezone

--- a/support/setup-toolchain.sh
+++ b/support/setup-toolchain.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-TOOLCHAIN_VERSION=v0.0.2
+TOOLCHAIN_VERSION=v0.0.3
 TOOLCHAIN_TAR="miyoomini-toolchain.tar.xz"
 
 TOOLCHAIN_ARCH=`uname -m`


### PR DESCRIPTION
## Summary

Incorporate upstream changes from [shauninman/union-miyoomini-toolchain](https://github.com/shauninman/union-miyoomini-toolchain):

- **Update base image** from `debian:buster-slim` to `debian/eol:buster-slim` (Buster is now EOL, original repos archived)
- **Bump toolchain version** from `v0.0.2` to `v0.0.3` (adds libmad & libvorbis for vvvvvv)

Trying to build the image without this change will result in errors like the following during the `RUN apt-get -y update` build step:

```
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
```

To keep this PR clean/simple, the following are deferred to later PRs:
* upgrading to non-EOL debian base image
* optimizing `RUN apt-get` Docker build layers
* fixing potential issues in setup scripts

## Upstream Commits

Cherry-picked from:
- https://github.com/shauninman/union-miyoomini-toolchain/commit/cfcae30
- https://github.com/shauninman/union-miyoomini-toolchain/commit/90ce1ec

## Testing

- [x] Docker image builds successfully
- [x] ARM cross-compiler verified working: `arm-linux-gnueabihf-gcc (Linaro GCC 8.3.0)`

### ARM cross-compiler output
```
❯ docker run --rm aemiii91/miyoomini-toolchain:latest /bin/bash -c 'source /root/
.bashrc && arm-linux-gnueabihf-gcc --version'

arm-linux-gnueabihf-gcc (Linaro GCC 8.2-2018.08~dev) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```


